### PR TITLE
Use Matrix4 for viewProjection to allow for 3D UI

### DIFF
--- a/src/Magnum/Ui/AbstractUiShader.h
+++ b/src/Magnum/Ui/AbstractUiShader.h
@@ -30,7 +30,7 @@
  */
 
 #include <Magnum/GL/AbstractShaderProgram.h>
-#include <Magnum/Math/Matrix3.h>
+#include <Magnum/Math/Matrix4.h>
 
 namespace Magnum { namespace Ui {
 
@@ -45,7 +45,7 @@ class AbstractUiShader: public GL::AbstractShaderProgram {
          * @brief Set transformation and projection matrix
          * @return Reference to self (for method chaining)
          */
-        AbstractUiShader& setTransformationProjectionMatrix(const Matrix3& matrix) {
+        AbstractUiShader& setTransformationProjectionMatrix(const Matrix4& matrix) {
             setUniform(_transformationProjectionMatrixUniform, matrix);
             return *this;
         }

--- a/src/Magnum/Ui/BackgroundShader.vert
+++ b/src/Magnum/Ui/BackgroundShader.vert
@@ -30,7 +30,7 @@ layout(std140) uniform Style {
 
 #define cornerRadius noneCornerRadiusNoneSmoothnessOut.y
 
-uniform mediump mat3 transformationProjectionMatrix;
+uniform mediump mat4 transformationProjectionMatrix;
 
 layout(location = 0) in mediump vec2 vertexPosition;
 layout(location = 1) in mediump vec4 edgeDistance;
@@ -52,5 +52,5 @@ void main() {
 
     mediump vec2 position = rect.xy + vertexPosition*rectSize;
 
-    gl_Position = vec4(transformationProjectionMatrix*vec3(position, 1.0), 0.0).xywz;
+    gl_Position = transformationProjectionMatrix*vec4(position, 0.0, 1.0);
 }

--- a/src/Magnum/Ui/BasicPlane.h
+++ b/src/Magnum/Ui/BasicPlane.h
@@ -295,9 +295,9 @@ template<class ...Layers> class BasicPlane: public AbstractPlane {
         template<std::size_t i> void updateInternal(std::integral_constant<std::size_t, i>);
         void updateInternal(std::integral_constant<std::size_t, sizeof...(Layers)>) {}
 
-        void draw(const Matrix3& projectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders);
-        template<std::size_t i> void drawInternal(const Matrix3& transformationProjectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders, std::integral_constant<std::size_t, i>);
-        void drawInternal(const Matrix3&, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>&, std::integral_constant<std::size_t, sizeof...(Layers)>) {}
+        void draw(const Matrix4& projectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders);
+        template<std::size_t i> void drawInternal(const Matrix4& transformationProjectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders, std::integral_constant<std::size_t, i>);
+        void drawInternal(const Matrix4&, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>&, std::integral_constant<std::size_t, sizeof...(Layers)>) {}
 
         std::tuple<Layers&...> _layers;
 };

--- a/src/Magnum/Ui/BasicPlane.hpp
+++ b/src/Magnum/Ui/BasicPlane.hpp
@@ -55,11 +55,11 @@ template<class ...Layers> template<std::size_t i> void BasicPlane<Layers...>::up
     updateInternal(std::integral_constant<std::size_t, i + 1>{});
 }
 
-template<class ...Layers> void BasicPlane<Layers...>::draw(const Matrix3& projectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders) {
-    drawInternal(projectionMatrix*Matrix3::translation(rect().min()), shaders, std::integral_constant<std::size_t, 0>{});
+template<class ...Layers> void BasicPlane<Layers...>::draw(const Matrix4& projectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders) {
+    drawInternal(projectionMatrix*Matrix4::translation(Vector3{rect().min(), 0.0f}), shaders, std::integral_constant<std::size_t, 0>{});
 }
 
-template<class ...Layers> template<std::size_t i> void BasicPlane<Layers...>::drawInternal(const Matrix3& transformationProjectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders, std::integral_constant<std::size_t, i>) {
+template<class ...Layers> template<std::size_t i> void BasicPlane<Layers...>::drawInternal(const Matrix4& transformationProjectionMatrix, const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders, std::integral_constant<std::size_t, i>) {
     shaders[i].get().setTransformationProjectionMatrix(transformationProjectionMatrix);
     std::get<i>(_layers).draw(shaders[i]);
     drawInternal(transformationProjectionMatrix, shaders, std::integral_constant<std::size_t, i + 1>{});

--- a/src/Magnum/Ui/BasicUserInterface.cpp
+++ b/src/Magnum/Ui/BasicUserInterface.cpp
@@ -31,7 +31,7 @@
 
 namespace Magnum { namespace Ui {
 
-AbstractUserInterface::AbstractUserInterface(const Vector2& size, const Vector2i& screenSize): _size{size}, _coordinateScaling{size/Vector2{screenSize}} {}
+AbstractUserInterface::AbstractUserInterface(const Vector2& size, const Vector2i& screenSize): _size{size}, _coordinateScaling{size/Vector2{screenSize}}, _viewProjection{} {}
 
 AbstractUserInterface::~AbstractUserInterface() = default;
 

--- a/src/Magnum/Ui/BasicUserInterface.h
+++ b/src/Magnum/Ui/BasicUserInterface.h
@@ -35,6 +35,7 @@
 #include <Corrade/Containers/LinkedList.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Range.h>
+#include <Magnum/Math/Matrix4.h>
 
 #include "Magnum/Ui/Ui.h"
 #include "Magnum/Ui/visibility.h"
@@ -79,6 +80,11 @@ class MAGNUM_UI_EXPORT AbstractUserInterface: private Containers::LinkedList<Abs
         /** @brief Handle application mouse release event */
         bool handleReleaseEvent(const Vector2i& screenPosition);
 
+        /** @brief Set view projection matrix */
+        void setViewProjectionMatrix(const Matrix4& viewProjection) {
+            _viewProjection = viewProjection;
+        }
+
     private:
         #ifndef DOXYGEN_GENERATING_OUTPUT /* https://bugzilla.gnome.org/show_bug.cgi?id=776986 */
         friend Containers::LinkedList<AbstractPlane>;
@@ -93,6 +99,7 @@ class MAGNUM_UI_EXPORT AbstractUserInterface: private Containers::LinkedList<Abs
 
         Vector2 _size;
         Vector2 _coordinateScaling;
+        Matrix4 _viewProjection;
 };
 
 /**

--- a/src/Magnum/Ui/BasicUserInterface.hpp
+++ b/src/Magnum/Ui/BasicUserInterface.hpp
@@ -41,7 +41,7 @@ template<class ...Layers> void BasicUserInterface<Layers...>::update() {
 }
 
 template<class ...Layers> void BasicUserInterface<Layers...>::draw(const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders) {
-    const Matrix3 projectionMatrix = Matrix3::scaling(2.0f/_size)*Matrix3::translation(-_size/2);
+    const Matrix4 projectionMatrix = Matrix4::scaling(Vector3{2.0f/_size, 1.0f})*Matrix4::translation(Vector3{-_size/2, 0.0f});
     for(AbstractPlane& plane: *this) {
         /* Ignore all hidden planes in the back, draw back-to-front */
         if(plane.flags() & PlaneFlag::Hidden) continue;

--- a/src/Magnum/Ui/BasicUserInterface.hpp
+++ b/src/Magnum/Ui/BasicUserInterface.hpp
@@ -41,7 +41,8 @@ template<class ...Layers> void BasicUserInterface<Layers...>::update() {
 }
 
 template<class ...Layers> void BasicUserInterface<Layers...>::draw(const std::array<std::reference_wrapper<AbstractUiShader>, sizeof...(Layers)>& shaders) {
-    const Matrix4 projectionMatrix = Matrix4::scaling(Vector3{2.0f/_size, 1.0f})*Matrix4::translation(Vector3{-_size/2, 0.0f});
+    const Matrix4 projectionMatrix = _viewProjection*Matrix4::scaling(Vector3{2.0f/_size, 1.0f})*Matrix4::translation(Vector3{-_size/2.0f, 0.0f});
+
     for(AbstractPlane& plane: *this) {
         /* Ignore all hidden planes in the back, draw back-to-front */
         if(plane.flags() & PlaneFlag::Hidden) continue;

--- a/src/Magnum/Ui/ForegroundShader.vert
+++ b/src/Magnum/Ui/ForegroundShader.vert
@@ -30,7 +30,7 @@ layout(std140) uniform Style {
 
 #define cornerRadius borderWidthCornerRadiusSmoothnessInOut.y
 
-uniform mediump mat3 transformationProjectionMatrix;
+uniform mediump mat4 transformationProjectionMatrix;
 
 layout(location = 0) in mediump vec2 vertexPosition;
 layout(location = 1) in mediump vec4 edgeDistance;
@@ -54,5 +54,5 @@ void main() {
 
     mediump vec2 position = rect.xy + vertexPosition*rectSize;
 
-    gl_Position = vec4(transformationProjectionMatrix*vec3(position, 1.0), 0.0).xywz;
+    gl_Position = transformationProjectionMatrix*vec4(position, 0.0, 1.0);
 }

--- a/src/Magnum/Ui/TextShader.vert
+++ b/src/Magnum/Ui/TextShader.vert
@@ -23,7 +23,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-uniform mediump mat3 transformationProjectionMatrix;
+uniform mediump mat4 transformationProjectionMatrix;
 
 layout(location = 0) in mediump vec4 position;
 layout(location = 1) in mediump vec2 textureCoordinates;
@@ -36,5 +36,5 @@ void main() {
     fragmentColorIndex = colorIndex;
     fragmentTextureCoordinates = textureCoordinates;
 
-    gl_Position = vec4(transformationProjectionMatrix*position.xyw, 0.0).xywz;
+    gl_Position = transformationProjectionMatrix*position;
 }


### PR DESCRIPTION
Hi @mosra !

As discussed, I changed all the `Matrix3` projection matrices to `Matrix4` to allow for arbitrary transforms of UserInterfaces.
I also added `AbstractUserInterface::setViewProjectionMatrix`. We should question whether this is the right approach. As far as I see, this does not allow separating planes from each other yet, hence, having a single `UserInterface` with multiple panels with their own 3D transformations each.
Will look into that soon, though.

Thanks in advance!

Cheers, Jonathan.