### PR TITLE
fix to allow building on both Ubuntu 16.04 and 18.04.

### DIFF
--- a/package/debian/control
+++ b/package/debian/control
@@ -1,7 +1,7 @@
 Source: magnum-extras
 Priority: optional
 Maintainer: Vladimír Vondruš <mosra@centrum.cz>
-Build-Depends: debhelper (>= 9), cmake (>= 2.8.12)
+Build-Depends: debhelper (>= 9), cmake (>= 2.8.12), corrade-dev, magnum-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://magnum.graphics
@@ -11,14 +11,14 @@ Vcs-Browser: https://github.com/mosra/magnum-extras
 Package: magnum-extras-dev
 Section: libdevel
 Architecture: any
-Depends: magnum-extras (= ${binary:Version}), magnum-dev
+Depends: magnum-extras (= ${binary:Version}), corrade-dev, magnum-dev
 Description: Magnum Extras development files
  Headers and tools needed for developing with Magnum Plugins.
 
 Package: magnum-extras
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, magnum
+Depends: ${shlibs:Depends}, ${misc:Depends}, corrade, magnum
 Description: Extras for the Magnum C++11/C++14 graphics engine
  Magnum is 2D/3D graphics engine written in C++11 and modern OpenGL. Its goal
  is to simplify low-level graphics development and interaction with OpenGL


### PR DESCRIPTION
As promised in https://github.com/mosra/magnum/issues/248, here is a PR that will allow builds to work for both Ubuntu 18.04 and 16.04. Note that some of the changes are also to allow the build to work correctly in Launchpad, as it builds from a clean chroot every time dependencies may not be available.