### PR TITLE
[WIP] Player: make it possible to drop folders

### DIFF
--- a/src/player/player.html
+++ b/src/player/player.html
@@ -20,13 +20,24 @@
   <script>
     "use strict"; /* it summons the Cthulhu in a proper way, they say */
 
-    function handleDragOver(event) {
+    /* Done here instead of using Sdl2Application::setContainerCssClass() so
+       we can do extra things like hiding scrollbars on magnum.graphics. Not
+       needed here though. */
+    function setFullsize(fullsize) {
+        if(fullsize) {
+            document.getElementById('container').className = 'fullsize';
+        } else {
+            document.getElementById('container').className = '';
+        }
+    }
+
+    Module.keyboardListeningElement = Module.canvas;
+    Module.canvas.addEventListener('dragover', function(event) {
         event.stopPropagation();
         event.preventDefault();
         event.dataTransfer.dropEffect = 'copy';
-    }
-
-    function handleDrop(event) {
+    });
+    Module.canvas.addEventListener('drop', function(event) {
         event.stopPropagation();
         event.preventDefault();
 
@@ -55,22 +66,7 @@
                 fileReader.readAsArrayBuffer(file);
             })(files[i]); /* this is how you do a capturing lambda?! ugh */
         }
-    }
-
-    /* Done here instead of using Sdl2Application::setContainerCssClass() so
-       we can do extra things like hiding scrollbars on magnum.graphics. Not
-       needed here though. */
-    function setFullsize(fullsize) {
-        if(fullsize) {
-            document.getElementById('container').className = 'fullsize';
-        } else {
-            document.getElementById('container').className = '';
-        }
-    }
-
-    Module.keyboardListeningElement = Module.canvas;
-    Module.canvas.addEventListener('drop', handleDrop);
-    Module.canvas.addEventListener('dragover', handleDragOver);
+    });
     Module.canvas.addEventListener('mousedown', function(event) {
         event.target.focus();
     });

--- a/src/player/player.html
+++ b/src/player/player.html
@@ -41,15 +41,49 @@
         event.stopPropagation();
         event.preventDefault();
 
-        const files = event.dataTransfer.files;
-        if(!files) {
+        const items = event.dataTransfer.items;
+        if(!items) {
             console.error("No files dropped.");
             return;
         }
 
-        /* Pass all files through to the player. Memory is allocated on the
-           JS side and freed on the C++ side to avoid needless copies. */
-        for(let i = 0; i != files.length; ++i) {
+        /* Unrecurse the bag of dropped files and directories and then pass all
+           files through to the player. Memory is allocated on the JS side and
+           freed on the C++ side to avoid needless copies. The
+           webkitGetAsEntry() is Chrome-specific and Firefox with Edge were
+           forced to implement it, despite the name. Safari and IE don't know
+           that, so we need to be careful. */
+        var files = [];
+        var traverseFiles = function(fileOrDirectory, path/*, files*/) {
+            if(fileOrDirectory.isFile) {
+//                 console.log(files);
+                files.push([fileOrDirectory, path]);
+            } else if(fileOrDirectory.isDirectory) {
+                let dirReader = fileOrDirectory.createReader();
+                let getE = function() {
+                dirReader.readEntries(function(entries) {
+                    for(let i = 0; i != entries.length; ++i) {
+                        traverseFiles(entries[i], path + fileOrDirectory.name + "/"/*, files*/);
+                    }
+                });
+                }
+
+                getE();
+            }
+        };
+        for(let i = 0; i != items.length; ++i) {
+            /* TODO: this might get renamed to getAsEntry() in 2027 or so */
+            if(typeof items[i].webkitGetAsEntry === "function") {
+                traverseFiles(items[i].webkitGetAsEntry(), ""/*, files*/);
+                continue;
+            }
+
+            /* If webkitGetAsEntry() is not supported or the dumpster is on
+               fire some other way, simply push the file directly (it will fail
+               later if directories are involved). This is duplicated below
+               for the case of webkitGetAsEntry() supported -- it uses a
+               different variable for total count and adds file path to the
+               filename. */
             (function(file) {
                 const fileReader = new FileReader();
                 fileReader.onload = function(event) {
@@ -58,13 +92,34 @@
                     const pointer = Module._malloc(fileData.length);
                     const data = new Uint8Array(Module.HEAPU8.buffer, pointer, fileData.length);
                     data.set(fileData);
-                    Module.ccall('loadFile', null, ['number', 'string', 'number', 'number'], [files.length, file.name, pointer, fileData.length]);
+                    Module.ccall('loadFile', null, ['number', 'string', 'number', 'number'], [items.length, file.name, pointer, fileData.length]);
                 };
                 fileReader.onerror = function() {
                     console.error("Unable to read file " + file.name);
                 };
                 fileReader.readAsArrayBuffer(file);
-            })(files[i]); /* this is how you do a capturing lambda?! ugh */
+            })(items[i]); /* this is how you do a capturing lambda?! ugh */
+        }
+        console.log(files.length);
+        for(let i = 0; i != files.length; ++i) {
+            console.log("ugh", i);
+        (function(file, path) {
+            file.file(function(file) {
+                const fileReader = new FileReader();
+                fileReader.onload = function(event) {
+                    /* TODO: but still, isn't here way too much copying? */
+                    const fileData = new Uint8Array(event.target.result);
+                    const pointer = Module._malloc(fileData.length);
+                    const data = new Uint8Array(Module.HEAPU8.buffer, pointer, fileData.length);
+                    data.set(fileData);
+                    Module.ccall('loadFile', null, ['number', 'string', 'number', 'number'], [files.length, path + file.name, pointer, fileData.length]);
+                };
+                fileReader.onerror = function() {
+                    console.error("Unable to read file " + file.name);
+                };
+                fileReader.readAsArrayBuffer(file);
+            });
+        })(files[i][0], files[i][1]); /* insane?! is this needed? */
         }
     });
     Module.canvas.addEventListener('mousedown', function(event) {


### PR DESCRIPTION
It's a Chrome-specific callback hell that Firefox [was forced to implement](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/50#Files_and_directories), now should be also available in Edge. Not in IE or Safari, so we need to be careful.

With the current state, I need to gather the total count of files to load before submitting them in order to make it possible for the C++ side to know when everything is ready and we can't start import. But because it's one callback per directory, I have no idea how to do this.

Any help from actual web devs who know what they're doing in appreciated (because I'm not a web dev and neither I know what I'm doing). Thanks in advance.

Related SO thread that I based the implementation on: https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree